### PR TITLE
Fix markdown import error.

### DIFF
--- a/strange_case/extensions/markdown.py
+++ b/strange_case/extensions/markdown.py
@@ -10,7 +10,7 @@ try:
     import pygments
 except ImportError:
     from strange_case import require_package
-    recommend_package('pygments')
+    require_package('pygments')
 
 
 markdowner = markdown2.Markdown(extras=["fenced-code-blocks", "header-ids",


### PR DESCRIPTION
This fixes the following error:

```

Traceback (most recent call last):
  File "../bin/scase", line 8, in <module>
    load_entry_point('StrangeCase==v4.0.5', 'console_scripts', 'scase')()
  File "/Users/wichert/Development/sc/lib/python2.7/site-packages/strange_case/__main__.py", line 114, in run
    extension = fancy_import(extension)
  File "/Users/wichert/Development/sc/lib/python2.7/site-packages/strange_case/__main__.py", line 20, in fancy_import
    imported = __import__(import_path, globals(), locals(), [import_me], -1)
  File "/Users/wichert/Development/sc/lib/python2.7/site-packages/strange_case/extensions/markdown.py", line 13, in <module>
    recommend_package('pygments')
NameError: name 'recommend_package' is not defined
```
