### PR TITLE
Fixed Jinja on Windows (it choked on "\"-paths)

### DIFF
--- a/strange_case/nodes/jinja.py
+++ b/strange_case/nodes/jinja.py
@@ -1,6 +1,6 @@
 from strange_case.nodes import PageNode
 from strange_case.registry import Registry
-
+from strange_case.support.jinja import fix_path
 
 class JinjaNode(PageNode):
     """
@@ -16,8 +16,9 @@ class JinjaNode(PageNode):
         self.files_written.append(target_path)
 
     def render(self, site=None):
+        #print "self.source_path is '{}', fixed to '{}'".format(self.source_path, fix_path(self.source_path))
         try:
-            template = Registry.get('jinja_environment').get_template(self.source_path)
+            template = Registry.get('jinja_environment').get_template(fix_path(self.source_path))
         except UnicodeDecodeError as e:
             e.args += "Could not process '%s' because of unicode error." % self.source_path
             raise


### PR DESCRIPTION
Added strange_case.support.jinja.fix_path, which is used in
StrangeCaseEnvironment.__init__() and JinjaNode.render().

As it says in the docstring:

Jinja chokes on backslash-separated paths, and slash-separatd
paths work well enough in Windows anyway.  See also [Jinja2-99](https://github.com/mitsuhiko/jinja2/pull/99),
[Jinja2-98](https://github.com/mitsuhiko/jinja2/issues/98).
