### PR TITLE
Add .pyc, .egg-info, vim files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 public/
 *.pxm
+*.pyc
+*.egg-info
+
+# Vim files
+.*~
+*.swp
+*~


### PR DESCRIPTION
For some reason, GitHub for Windows doesn't respect my global
.gitignore.

I've seen people object to having per-project .gitignore files,
so no hard feelings if you reject this one.  It would just be nice
to not have Github for Windows not say I have 50+ files to commit
every time I run `python setup.py develop`
